### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ volley
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
 
-###1.支持http 大文件上传以及下载，支持断点下载，下载中允许暂停，下次从暂停地方开始下载
-####初始化
+### 1.支持http 大文件上传以及下载，支持断点下载，下载中允许暂停，下次从暂停地方开始下载
+#### 初始化
 <p><code>HttpTools.init(context);</code></p>
 建议在Application的OnCreate中执行一次（可选）
-####普通http请求
+#### 普通http请求
 本来有八种谓词，考虑其他几种不常见，项目中用不上，暂时不提供。
 HttpTools提供get，post，upload，download，delete多种请求的封装，一行代码搞定各种异步请求
 
@@ -19,14 +19,14 @@ HttpTools提供get，post，upload，download，delete多种请求的封装，�
     delete(RequestInfo requestInfo, final HttpCallback httpResult);  
     put(RequestInfo requestInfo, final HttpCallback httpResult);
 
-####文件下载
+#### 文件下载
 
     DownloadRequest download(String url, String target, final boolean isResume, final HttpCallback httpResult)
     DownloadRequest download(RequestInfo requestInfo, String target, final boolean isResume, final HttpCallback httpResult)
 
 设置参数isResume为true，即可实现断点续传，DownloadRequest提供stopDownload方法，可以随时停止当前的下载任务，再次下载将会从上次下载的地方开始下载。quitDownloadQueue允许强制关闭下载线程池，退出下载。可以在所有下载任务完成后关闭，节约资源。
 
-####文件上传
+#### 文件上传
 
     MultiPartRequest<String> upload(final String url, final Map<String, Object> params, final HttpCallback httpResult)
     MultiPartRequest<String> upload(RequestInfo requestInfo, final HttpCallback httpResult)
@@ -39,12 +39,12 @@ Params是一个表单参数，可以传入string和File类型的参数。（可�
     params.put("file2", new File("/sdcard/a.jpg"));  
     params.put("name", "张三");  
     mHttpTools.upload(url, params, httpResult);
-####直接使用Volley的Request
+#### 直接使用Volley的Request
      public <T> void sendRequest(Request<T> request)
 
-###2.默认开启gzip压缩
+### 2.默认开启gzip压缩
 ImageRequest和DownloadRequest不启用Gzip，其他请求均默认开启Gzip
-###3.支持本地图片（res,asset,sdcard）
+### 3.支持本地图片（res,asset,sdcard）
 	Bitmap getBitmapFromRes(int resId);
 	Bitmap getBitmapFromAsset(String filePath);
 	Bitmap getBitmapFromContent(String imageUri);
@@ -56,11 +56,11 @@ ImageRequest和DownloadRequest不启用Gzip，其他请求均默认开启Gzip
 （比如需要异步加载一张resource中的图片的话，可以这样定义
 	bitmapTools.display(view,BitmapDecoder.SCHEME_RES+R.drawable.xxx);
 加载sdcard中的文件不需要加协议头）
-####初始化
+#### 初始化
 
     BitmapTools.init(context);
     
-####结束（可以在app退出后调用）
+#### 结束（可以在app退出后调用）
 
     BitmapTools.stop();
 
@@ -82,15 +82,15 @@ BitmapTools中提供多种方法配置BitmapDisplayConfig，配置过后，Bitma
 
     bitmapTools.display(final View view, String uri, BitmapDisplayConfig displayConfig);
 
-###4.diskcache默认使用DiskLruCache，memoryCache默认使用LruCache
+### 4.diskcache默认使用DiskLruCache，memoryCache默认使用LruCache
 
-###5.request请求添加进度监听（包括上传进度以及加载进度）
+### 5.request请求添加进度监听（包括上传进度以及加载进度）
 
-###6.允许暂停和继续请求队列
+### 6.允许暂停和继续请求队列
 
     bitmapTools.resume();
     bitmapTools.pause();
-###7.DbTools模块
+### 7.DbTools模块
 数据库模块集成了xUtils中DbUtils。  
 使用方法参考xUtils。  
 注意：  


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
